### PR TITLE
Catch NPE on AppOpticsDto when there are no Measurements

### DIFF
--- a/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsDto.java
+++ b/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsDto.java
@@ -16,7 +16,7 @@
 package io.micrometer.appoptics;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,36 +36,26 @@ public class AppOpticsDto {
     private final List<Measurement> measurements;
 
     private AppOpticsDto(Builder builder) {
-        time = builder.time;
-        period = builder.period;
-        tags = builder.tags;
-        measurements = builder.measurements;
+        this.time = builder.time;
+        this.period = builder.period;
+        this.tags = Collections.unmodifiableMap(builder.tags);
+        this.measurements = Collections.unmodifiableList(builder.measurements);
     }
 
     public static Builder newBuilder() {
         return new Builder();
     }
 
-    public AppOpticsDto addMeasurement(Measurement measurement) {
-        measurements.add(measurement);
-        return this;
-    }
-
-    public AppOpticsDto addMeasurements(Stream<Measurement> measurements) {
-        measurements.forEach(this.measurements::add);
-        return this;
-    }
-
     public List<Measurement> getMeasurements() {
-        return measurements;
+        return this.measurements;
     }
 
     public List<AppOpticsDto> batch(int size) {
 
-        if(this.measurements.size() <= size) {
-            return Arrays.asList(this);
+        if(getMeasurements().size() <= size) {
+            return Collections.singletonList(this);
         }
-        final List<AppOpticsDto> batches = new ArrayList();
+        final List<AppOpticsDto> batches = new ArrayList<>();
         for (int i = 0; i < this.measurements.size(); i += size) {
             batches.add(AppOpticsDto.newBuilder()
                 .withPeriod(this.period)
@@ -96,14 +86,8 @@ public class AppOpticsDto {
     public static final class Builder {
         private long time;
         private int period;
-        private Map<String, String> tags;
-        private List<Measurement> measurements;
-
-        private Builder() {
-
-            this.measurements = new ArrayList();
-            this.tags = new HashMap();
-        }
+        private Map<String, String> tags = new HashMap<>();
+        private List<Measurement> measurements = new ArrayList<>();
 
         public Builder withTime(long val) {
             time = val;
@@ -127,8 +111,18 @@ public class AppOpticsDto {
             return this;
         }
 
-        public Builder withMeasurements(List<Measurement> val) {
-            measurements = val;
+        public Builder withMeasurements(List<Measurement> measurements) {
+            this.measurements.addAll(measurements);
+            return this;
+        }
+
+        public Builder withMeasurements(Stream<Measurement> measurementStream) {
+            measurementStream.forEach( this.measurements::add);
+            return this;
+        }
+
+        public Builder withMeasurement(Measurement measurement) {
+            this.measurements.add(measurement);
             return this;
         }
 

--- a/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsDto.java
+++ b/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsDto.java
@@ -52,7 +52,7 @@ public class AppOpticsDto {
 
     public List<AppOpticsDto> batch(int size) {
 
-        if(getMeasurements().size() <= size) {
+        if(this.measurements.size() <= size) {
             return Collections.singletonList(this);
         }
         final List<AppOpticsDto> batches = new ArrayList<>();

--- a/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsMeterRegistry.java
+++ b/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsMeterRegistry.java
@@ -82,13 +82,14 @@ public class AppOpticsMeterRegistry extends StepMeterRegistry {
         try {
             final URL endpoint = URI.create(config.uri()).toURL();
 
-            final AppOpticsDto dto = AppOpticsDto.newBuilder()
+            final AppOpticsDto.Builder dtoBuilder = AppOpticsDto.newBuilder()
                 .withTime(System.currentTimeMillis() / 1000)
                 .withPeriod((int) config.step().getSeconds())
-                .withTag("source", config.source())
-                .build();
+                .withTag("source", config.source());
 
-            getMeters().forEach(meter -> addMeter(meter, dto));
+            getMeters().forEach(meter -> addMeter(meter, dtoBuilder));
+
+            final AppOpticsDto dto = dtoBuilder.build();
 
             if(dto.getMeasurements().isEmpty()) {
                 logger.debug("No metrics to send.");
@@ -104,28 +105,28 @@ public class AppOpticsMeterRegistry extends StepMeterRegistry {
         }
     }
 
-    private void addMeter(Meter meter, AppOpticsDto dto) {
+    private void addMeter(Meter meter, AppOpticsDto.Builder dto) {
 
         if (meter instanceof Timer) {
-            dto.addMeasurement(fromTimer((Timer) meter));
+            dto.withMeasurement(fromTimer((Timer) meter));
         } else if (meter instanceof FunctionTimer) {
-            dto.addMeasurement(fromFunctionTimer((FunctionTimer) meter));
+            dto.withMeasurement(fromFunctionTimer((FunctionTimer) meter));
         } else if (meter instanceof DistributionSummary) {
-            dto.addMeasurement(fromDistributionSummary((DistributionSummary) meter));
+            dto.withMeasurement(fromDistributionSummary((DistributionSummary) meter));
         } else if (meter instanceof TimeGauge) {
             final Measurement measurement = fromTimeGauge((TimeGauge) meter);
-            if(null != measurement) dto.addMeasurement(measurement);
+            if(null != measurement) dto.withMeasurement(measurement);
         } else if (meter instanceof Gauge) {
             final Measurement measurement = fromGauge((Gauge) meter);
-            if(null != measurement) dto.addMeasurement(measurement);
+            if(null != measurement) dto.withMeasurement(measurement);
         } else if (meter instanceof Counter) {
-            dto.addMeasurement(fromCounter((Counter) meter));
+            dto.withMeasurement(fromCounter((Counter) meter));
         } else if (meter instanceof FunctionCounter) {
-            dto.addMeasurement(fromFunctionCounter((FunctionCounter) meter));
+            dto.withMeasurement(fromFunctionCounter((FunctionCounter) meter));
         } else if (meter instanceof LongTaskTimer) {
-            dto.addMeasurement(fromLongTaskTimer((LongTaskTimer) meter));
+            dto.withMeasurement(fromLongTaskTimer((LongTaskTimer) meter));
         } else {
-            dto.addMeasurements(fromMeter(meter));
+            dto.withMeasurements(fromMeter(meter));
         }
     }
 


### PR DESCRIPTION
This happens on `AppOpticsMeterRegistry` instantiation when it tries to report and there are no `Meter`s added yet (thus no `Measurement`s to report)

I made `AppOpticsDto` immutable and moved all cases where `Measurement`(s) were added to solely use `AppOpticsDto.Builder`. This allows us to call `build()` on the builder and have an empty list of `Measurement`s created, so the reporter will not report.